### PR TITLE
Show the MainTaskList on our MainCareerPage

### DIFF
--- a/app/javascript/components/App.js
+++ b/app/javascript/components/App.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types"
 import CareerMainPage from './CareerMainPage'
 import CreateJob from './pages/jobs/CreateJob'
 import ShowCurrentJob from './pages/jobs/ShowCurrentJob'
+
 import 'bootstrap/dist/css/bootstrap.min.css';
 import { useState } from 'react'
 
@@ -19,6 +20,7 @@ function App(props) {
 
     const [ errors, setErrors ] = useState(null)
     const [ apiJobsData, setApiJobsData ] = useState([])
+
     const [taskList, setTaskList] = useState([
         {
             description: "Task1 for job 1 User 1",
@@ -29,8 +31,8 @@ function App(props) {
             job_id: 2
         },
         {
-            description: "Task2 for job 3 for User 2",
-            job_id: 3
+            description: "Task2 for job 4 for User 2",
+            job_id: 4
         },
     ])
 

--- a/app/javascript/components/App.js
+++ b/app/javascript/components/App.js
@@ -21,7 +21,7 @@ function App(props) {
     const [ errors, setErrors ] = useState(null)
     const [ apiJobsData, setApiJobsData ] = useState([])
 
-    const [taskList, setTaskList] = useState([
+    const [tasks, setTasks] = useState([
         {
             description: "Task1 for job 1 User 1",
             job_id: 1
@@ -79,6 +79,7 @@ function App(props) {
                                     getJob= {getJob}
                                     apiJobsData={apiJobsData}
                                     loadJobs={loadJobs}
+                                    tasks={tasks}
                                  />
                             </Route>
 

--- a/app/javascript/components/App.js
+++ b/app/javascript/components/App.js
@@ -19,6 +19,20 @@ function App(props) {
 
     const [ errors, setErrors ] = useState(null)
     const [ apiJobsData, setApiJobsData ] = useState([])
+    const [taskList, setTaskList] = useState([
+        {
+            description: "Task1 for job 1 User 1",
+            job_id: 1
+        },
+        {
+            description: "Task2 for job 2 User 1",
+            job_id: 2
+        },
+        {
+            description: "Task2 for job 3 for User 2",
+            job_id: 3
+        },
+    ])
 
     function getJob() {
         return fetch('/jobs')

--- a/app/javascript/components/App.js
+++ b/app/javascript/components/App.js
@@ -59,7 +59,10 @@ function App(props) {
                         <Switch>
                             <Route exact path="/careermainpage">
                                 <CareerMainPage
-                                    current_user_id={current_user_id} getJob= {getJob}
+                                    current_user_id={current_user_id}
+                                    getJob= {getJob}
+                                    apiJobsData={apiJobsData}
+                                    loadJobs={loadJobs}
                                  />
                             </Route>
 

--- a/app/javascript/components/CareerMainPage.js
+++ b/app/javascript/components/CareerMainPage.js
@@ -7,18 +7,7 @@ import { useState, useEffect } from 'react'
 function CareerMainPage(props) {
 
     const {current_user_id, getJob} = props
-    const [ errors, setErrors ] = useState(null)
-    const [ apiJobsData, setApiJobsData ] = useState([])
 
-    function loadJobs(){
-        getJob()
-            .then(jobs => {
-                if(jobs.errors) {
-                    setErrors(jobs.errors)
-                }
-                setApiJobsData(jobs)
-            })
-    }
 
     useEffect(() => {
         loadJobs()

--- a/app/javascript/components/CareerMainPage.js
+++ b/app/javascript/components/CareerMainPage.js
@@ -1,6 +1,8 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { Link } from 'react-router-dom'
+import MainTaskList from './pages/tasks/tasklist/MainTaskList'
+
 import { useState, useEffect } from 'react'
 
 
@@ -24,9 +26,6 @@ function CareerMainPage(props) {
                         <Link to={`/jobs/${id}`}>
                             <div style = {{borderStyle: 'inset'}}>
                                 <h1> Name: {name} - Title: {title}</h1>
-                                <h2> Description: {description} </h2>
-                                <h2> Tasks: {tasks} </h2>
-                                <h2> Url:{url} </h2>
                             </div>
                         </Link>
                     </div>
@@ -36,6 +35,7 @@ function CareerMainPage(props) {
 
     return (
       <React.Fragment>
+        <MainTaskList />
         {displayJobs}
       </React.Fragment>
     );

--- a/app/javascript/components/CareerMainPage.js
+++ b/app/javascript/components/CareerMainPage.js
@@ -23,10 +23,10 @@ function CareerMainPage(props) {
                     <div key={index} >
                         <Link to={`/jobs/${id}`}>
                             <div style = {{borderStyle: 'inset'}}>
-                                <h1> {name}: {title}</h1>
-                                <h2> {description} </h2>
-                                <h2> {tasks} </h2>
-                                <h2> {url} </h2>
+                                <h1> Name: {name} - Title: {title}</h1>
+                                <h2> Description: {description} </h2>
+                                <h2> Tasks: {tasks} </h2>
+                                <h2> Url:{url} </h2>
                             </div>
                         </Link>
                     </div>

--- a/app/javascript/components/CareerMainPage.js
+++ b/app/javascript/components/CareerMainPage.js
@@ -8,7 +8,7 @@ import { useState, useEffect } from 'react'
 
 function CareerMainPage(props) {
 
-    const {current_user_id, getJob, apiJobsData, loadJobs} = props
+    const {current_user_id, getJob, apiJobsData, loadJobs, tasks} = props
 
 
     useEffect(() => {
@@ -35,7 +35,9 @@ function CareerMainPage(props) {
 
     return (
       <React.Fragment>
-        <MainTaskList />
+        <MainTaskList tasks={tasks} apiJobsData={apiJobsData}/>
+        <br></br>
+        <br></br>
         {displayJobs}
       </React.Fragment>
     );

--- a/app/javascript/components/CareerMainPage.js
+++ b/app/javascript/components/CareerMainPage.js
@@ -6,7 +6,7 @@ import { useState, useEffect } from 'react'
 
 function CareerMainPage(props) {
 
-    const {current_user_id, getJob} = props
+    const {current_user_id, getJob, apiJobsData, loadJobs} = props
 
 
     useEffect(() => {

--- a/app/javascript/components/pages/jobs/CreateJob.js
+++ b/app/javascript/components/pages/jobs/CreateJob.js
@@ -26,6 +26,7 @@ function CreateJob(){
         })
         .then( resp => {
             let json = resp.json()
+            setJobSuccess(true)
             return json
         })
     }
@@ -37,7 +38,6 @@ function CreateJob(){
 
     function handleClick() {
         createJob(jobData)
-        setJobSuccess(true)
     }
 
     return (

--- a/app/javascript/components/pages/jobs/ShowCurrentJob.js
+++ b/app/javascript/components/pages/jobs/ShowCurrentJob.js
@@ -106,10 +106,10 @@ function ShowCurrentJob(props) {
             {apiJobData &&
                 <div>
                     <div>
-                        <h1> {name}: {title}</h1>
-                        <h2> {description} </h2>
-                        <h2> {tasks} </h2>
-                        <h2> {url} </h2>
+                        <h1> Name: {name} - Title: {title}</h1>
+                        <h2> Description: {description} </h2>
+                        <h2> Tasks: {tasks} </h2>
+                        <h2> Url:{url} </h2>
 
                     </div>
                     {errors &&

--- a/app/javascript/components/pages/jobs/ShowCurrentJob.js
+++ b/app/javascript/components/pages/jobs/ShowCurrentJob.js
@@ -60,6 +60,7 @@ function ShowCurrentJob(props) {
                 setApiJobData(job)
             })
     }
+
     useEffect(() => {
         loadJob()
     },[])

--- a/app/javascript/components/pages/tasks/tasklist/MainTaskList.js
+++ b/app/javascript/components/pages/tasks/tasklist/MainTaskList.js
@@ -5,11 +5,30 @@ import { useState, useEffect } from 'react'
 
 
 function MainTaskList(props) {
+    const {tasks, apiJobsData} = props
+
+    // const {apiJobsData}
+
+    const taskList = tasks.map((task, index) => {
+        const {description, job_id} = task // we need the job id to compare
+        return(
+            <div key={index} style = {{borderStyle: 'inset'}}>
+                <h1> description: {description}</h1>
+            </div>
+        )
+    })
+
     return(
         <div style = {{borderStyle: 'inset'}}>
             <h1> MainTaskList </h1>
+            {taskList}
         </div>
     )
 }
 
 export default MainTaskList
+
+// {
+//     description: "Task1 for job 1 User 1",
+//     job_id: 1
+// },

--- a/app/javascript/components/pages/tasks/tasklist/MainTaskList.js
+++ b/app/javascript/components/pages/tasks/tasklist/MainTaskList.js
@@ -1,0 +1,15 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { Link, useParams, Redirect } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+
+
+function MainTaskList(props) {
+    return(
+        <div style = {{borderStyle: 'inset'}}>
+            <h1> MainTaskList </h1>
+        </div>
+    )
+}
+
+export default MainTaskList

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,28 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+user_attributes = [
+
+]
+
+job_attributes = [
+        {
+            name:"Google",
+            title: "SWE",
+            description: "Testing",
+            url: "Google.com",
+            user_id: 1
+        },
+        {
+            name:"Facebook",
+            title: "SWE-II",
+            description: "App making",
+            url: "Facebook.com",
+            user_id: 1
+        }
+]
+
+job_attributes.each do |attributes|
+    Job.create(attributes)
+end


### PR DESCRIPTION
# Discussion
The purpose of this feature was to have a component to show all our tasks in the MainCareerComponent

# Link to Story
![Screen Shot 2019-12-05 at 12 30 32 PM](https://user-images.githubusercontent.com/5475016/70271360-15988000-175b-11ea-8bc6-13b26bf50583.png)
https://trello.com/b/gdd479fk/echo-2019-capstone-project

# What we did for the PR
We were able to pass the Tasks dummy data from the App component, to CareerMainPage component, to the MainTaskList component.

# What we plan to do next
 Next thing is to start with what we did for the Jobs in creating the CRUD functionality for Tasks so we can fetch and use database data and not dummy data.