### PR TITLE
Title and Location fields added to edit task component

### DIFF
--- a/app/javascript/react/components/EditTaskComponent.js
+++ b/app/javascript/react/components/EditTaskComponent.js
@@ -54,6 +54,15 @@ function EditTaskComponent(props) {
             <Form className = "formContainer">
 
             <Form.Group controlId="formGroupDescription">
+              <Form.Label>Title:</Form.Label>
+              <Form.Control
+                type="text"
+                name="title"
+                onChange={handleChange}
+                value={taskData.title}
+              />
+            </Form.Group>
+            <Form.Group controlId="formGroupDescription">
               <Form.Label>Description:</Form.Label>
               <Form.Control
                 type="text"
@@ -61,6 +70,15 @@ function EditTaskComponent(props) {
                 onChange={handleChange}
                 value={taskData.description}
               />
+            </Form.Group>
+            <Form.Group>
+               <Form.Label>Location:</Form.Label>
+               <Form.Control
+                 type="text"
+                 name="location"
+                 onChange={handleChange}
+                 value={taskData.location}
+               />
             </Form.Group>
             <Button
                 className="centerbutton"


### PR DESCRIPTION
What I did for this PR:
Added title and location forms to the edit task component to reflect the additional columns that have been added to the tasks table.

Next Steps:
Implement ability to edit start and end datetimes utilizing the react datetime picker in the edit task component. Currently the only place these exist is in the create task page. (Icebox)
